### PR TITLE
Update to forge version 41.0.98

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -5,6 +5,6 @@ org.gradle.daemon=false
 mod_version=1.8.0
 
 #Dependencies
-forge_version=41.0.11
+forge_version=41.0.98
 minecraft_version=1.19
 jei_version=1.18.2:9.5.5.174

--- a/src/main/java/com/direwolf20/charginggadgets/DataGenerators.java
+++ b/src/main/java/com/direwolf20/charginggadgets/DataGenerators.java
@@ -30,9 +30,9 @@ import net.minecraftforge.client.model.generators.ModelFile;
 import net.minecraftforge.common.Tags;
 import net.minecraftforge.common.data.ExistingFileHelper;
 import net.minecraftforge.common.data.LanguageProvider;
+import net.minecraftforge.data.event.GatherDataEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
-import net.minecraftforge.forge.event.lifecycle.GatherDataEvent;
 
 import javax.annotation.Nullable;
 import java.util.List;

--- a/src/main/java/com/direwolf20/charginggadgets/blocks/BlockRegistry.java
+++ b/src/main/java/com/direwolf20/charginggadgets/blocks/BlockRegistry.java
@@ -16,8 +16,8 @@ import net.minecraftforge.registries.RegistryObject;
 
 public class BlockRegistry {
     public static final DeferredRegister<Block> BLOCKS = DeferredRegister.create(ForgeRegistries.BLOCKS, ChargingGadgets.MOD_ID);
-    public static final DeferredRegister<BlockEntityType<?>> TILES_ENTITIES = DeferredRegister.create(ForgeRegistries.BLOCK_ENTITIES, ChargingGadgets.MOD_ID);
-    public static final DeferredRegister<MenuType<?>> CONTAINERS = DeferredRegister.create(ForgeRegistries.CONTAINERS, ChargingGadgets.MOD_ID);
+    public static final DeferredRegister<BlockEntityType<?>> TILES_ENTITIES = DeferredRegister.create(ForgeRegistries.BLOCK_ENTITY_TYPES, ChargingGadgets.MOD_ID);
+    public static final DeferredRegister<MenuType<?>> CONTAINERS = DeferredRegister.create(ForgeRegistries.MENU_TYPES, ChargingGadgets.MOD_ID);
 
     public static final RegistryObject<Block> CHARGING_STATION = BLOCKS.register("charging_station", ChargingStationBlock::new);
 

--- a/src/main/java/com/direwolf20/charginggadgets/blocks/chargingstation/ChargingStationBlock.java
+++ b/src/main/java/com/direwolf20/charginggadgets/blocks/chargingstation/ChargingStationBlock.java
@@ -105,7 +105,7 @@ public class ChargingStationBlock extends Block implements EntityBlock {
         if (!(te instanceof ChargingStationTile))
             return InteractionResult.FAIL;
 
-        NetworkHooks.openGui((ServerPlayer) player, (MenuProvider) te, pos);
+        NetworkHooks.openScreen((ServerPlayer) player, (MenuProvider) te, pos);
         return InteractionResult.SUCCESS;
     }
 


### PR DESCRIPTION
Hello! I use charging gadgets to test some of the energy based mods I work on. I updated to the latest forge version and realized charging gadgets wouldn't launch because it was on an old version (before the several breaking changes). So I thought I'd lend a hand to show my appreciation for this mod. This PR is just to bring it to the latest forge version at time of writing.